### PR TITLE
Fix build after fig2dev package has been promoted from testing to community

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
         uses: xu-cheng/latex-action@v3
         with:
           pre_compile: ./prepare.sh
+          extra_system_packages: |
+            gnuplot
           root_file: facharbeit.tex
       - name: Collect Warnings
         id: warnings

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-apk add gnuplot
-apk add fig2dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+apk add fig2dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/
 
 fig2dev -L latex skizze1.fig skizze1.tex
 fig2dev -L latex skizze2.fig skizze2.tex


### PR DESCRIPTION
The package `fig2dev` seems to have been included and removed from the testing source.